### PR TITLE
Remove name fields from Azure resources

### DIFF
--- a/kustomize/azure/compute/aksclusterclass.yaml
+++ b/kustomize/azure/compute/aksclusterclass.yaml
@@ -17,9 +17,6 @@ specTemplate:
   nodeVMSize: Standard_B2s
   dnsNamePrefix: crossplane-aks
   disableRBAC: false
-  writeServicePrincipalTo:
-    name: akscluster-net
-    namespace: crossplane-system
   reclaimPolicy: Delete
   providerRef:
     name: azure-provider

--- a/kustomize/azure/kustomizeconfig.yaml
+++ b/kustomize/azure/kustomizeconfig.yaml
@@ -7,7 +7,3 @@ nameReference:
     fieldSpecs:
       - path: spec/providerRef/name
         kind: ResourceGroup
-  - kind: ResourceGroup
-    fieldSpecs:
-      - path: spec/name
-        kind: ResourceGroup

--- a/kustomize/azure/network/kustomizeconfig.yaml
+++ b/kustomize/azure/network/kustomizeconfig.yaml
@@ -17,13 +17,7 @@ nameReference:
         kind: Subnet
   - kind: VirtualNetwork
     fieldSpecs:
-      - path: spec/name
-        kind: VirtualNetwork
       - path: spec/virtualNetworkNameRef/name
-        kind: Subnet
-  - kind: Subnet
-    fieldSpecs:
-      - path: spec/name
         kind: Subnet
 
 # varReference is the list of fields that we tell Kustomize to process for

--- a/kustomize/azure/network/subnet.yaml
+++ b/kustomize/azure/network/subnet.yaml
@@ -4,7 +4,6 @@ kind: Subnet
 metadata:
   name: subnet
 spec:
-  name: subnet
   resourceGroupNameRef:
     name: resourcegroup
   virtualNetworkNameRef:

--- a/kustomize/azure/network/virtualnetwork.yaml
+++ b/kustomize/azure/network/virtualnetwork.yaml
@@ -4,7 +4,6 @@ kind: VirtualNetwork
 metadata:
   name: virtualnetwork
 spec:
-  name: virtualnetwork
   resourceGroupNameRef:
     name: resourcegroup
   location: $(LOCATION)

--- a/kustomize/azure/resourcegroup.yaml
+++ b/kustomize/azure/resourcegroup.yaml
@@ -4,7 +4,6 @@ kind: ResourceGroup
 metadata:
   name: resourcegroup
 spec:
-  name: resourcegroup
   location: Central US
   reclaimPolicy: Delete
   providerRef:


### PR DESCRIPTION
All Azure resources now use the crossplane.io/external-name annotation.