### PR TITLE
Run stack-azure-sample as non-root

### DIFF
--- a/.registry/behavior.yaml
+++ b/.registry/behavior.yaml
@@ -4,7 +4,7 @@ crd:
   kind: AzureSample
   apiVersion: azure.stacks.crossplane.io/v1alpha1
 engine:
-  controllerImage: crossplane/templating-controller:v0.3.0-rc
+  controllerImage: crossplane/templating-controller:v0.3.0
   type: kustomize
   kustomize:
     overlays:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,6 @@ WORKDIR /
 COPY kustomize /kustomize
 COPY .registry /.registry
 
+USER 1001
 # This container is meant to be used as CSI storage rather than a processing unit.
 ENTRYPOINT ["find", "/kustomize"]


### PR DESCRIPTION
This updates stack-azure-sample to run as a
non-root user as the Crossplane stack manager will
reject containers that attempt to run as root per
crossplane/crossplane#1444

Draft until new version of `templating-controller` is available to pin to.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>