### PR TITLE
fix AKS loadBalancer:{} not populating

### DIFF
--- a/kustomize/azure/compute/aksclusterclass.yaml
+++ b/kustomize/azure/compute/aksclusterclass.yaml
@@ -12,7 +12,7 @@ specTemplate:
   vnetSubnetIDRef:
     name: subnet
   location: $(LOCATION)
-  version: "1.14.8"
+  version: "1.15.10"
   nodeCount: 1
   nodeVMSize: Standard_B2s
   dnsNamePrefix: crossplane-aks


### PR DESCRIPTION
Using Kubernetes 1.15.10 instead of 1.14.8 for the target cluster populates the Azure LB external-IP  right away and this appears to fix #20.

Tested with crossplane v0.10, provider-azure v0.9.0, and app-wordpress v0.4.0.

External IP was populated in a few minutes:
```
kubectl --kubeconfig=remote.kubeconfig get services -n my-cool-app
NAME        TYPE           CLUSTER-IP     EXTERNAL-IP    PORT(S)        AGE
wordpress   LoadBalancer   10.0.114.183   104.42.52.86   80:30943/TCP   24m
```

And it looks happy:
```
kubectl --kubeconfig=remote.kubeconfig describe services -n my-cool-app
Name:                     wordpress
Namespace:                my-cool-app
Labels:                   app=wordpress
Annotations:              KubernetesApplication.workload.crossplane.io/name: my-cool-app-service
                          KubernetesApplication.workload.crossplane.io/namespace: workspace1
                          KubernetesApplication.workload.crossplane.io/uid: b7a3bea8-1f61-4d71-97d6-b230319139c6
Selector:                 app=wordpress
Type:                     LoadBalancer
IP:                       10.0.114.183
LoadBalancer Ingress:     104.42.52.86
Port:                     <unset>  80/TCP
TargetPort:               80/TCP
NodePort:                 <unset>  30551/TCP
Endpoints:                10.2.0.16:80
Session Affinity:         None
External Traffic Policy:  Cluster
Events:
  Type    Reason                Age                 From                Message
  ----    ------                ----                ----                -------
  Normal  UpdatedLoadBalancer   13m                 service-controller  Updated load balancer with new hosts
  Normal  EnsuringLoadBalancer  19s (x11 over 13m)  service-controller  Ensuring load balancer
  Normal  EnsuredLoadBalancer   19s (x10 over 12m)  service-controller  Ensured load balancer
```

but there are intermittent network errors: ERR_CONNECTION_TIMED_OUT when trying to access the site. maybe the loadbalancer health checks are causing issues, need to investigate more.