### PR TITLE
Delete Provider resource last

### DIFF
--- a/.registry/behavior.yaml
+++ b/.registry/behavior.yaml
@@ -4,7 +4,7 @@ crd:
   kind: AzureSample
   apiVersion: azure.stacks.crossplane.io/v1alpha1
 engine:
-  controllerImage: crossplane/templating-controller:v0.3.0
+  controllerImage: crossplane/templating-controller:v0.3.0-9.gb138971
   type: kustomize
   kustomize:
     overlays:

--- a/kustomize/azure/provider.yaml
+++ b/kustomize/azure/provider.yaml
@@ -2,6 +2,8 @@ apiVersion: azure.crossplane.io/v1alpha3
 kind: Provider
 metadata:
   name: azure-provider
+  annotations:
+    templatestacks.crossplane.io/deletion-priority: "-1"
 spec:
   credentialsSecretRef:
     namespace: $(CRED_SECRET_NAMESPACE)

--- a/kustomize/azure/provider.yaml
+++ b/kustomize/azure/provider.yaml
@@ -6,6 +6,6 @@ metadata:
     templatestacks.crossplane.io/deletion-priority: "-1"
 spec:
   credentialsSecretRef:
-    namespace: $(CRED_SECRET_NAMESPACE)
-    name: $(CRED_SECRET_NAME)
-    key: $(CRED_SECRET_KEY)
+    name: azure-account-creds
+    namespace: crossplane-system
+    key: credentials


### PR DESCRIPTION
Delete Provider resource last so that others can still use the credentials during their deletion process

Signed-off-by: Muvaffak Onus <onus.muvaffak@gmail.com>